### PR TITLE
Add Gnome Shell 45 compatibility.

### DIFF
--- a/convenience.js
+++ b/convenience.js
@@ -36,9 +36,9 @@ edits, primary deletions. Edits include only keeping TalkativeLog.
  * @param {string} msg
  * @constructor
  */
-function TalkativeLog(msg) {
+export function TalkativeLog(msg) {
     // Enable this for testing and logging
     if (false) {
-        log("[ESC]" + msg);
+        console.log("[ESC]" + msg);
     }
 }

--- a/display_module.js
+++ b/display_module.js
@@ -5,14 +5,12 @@ edits. We primarily need the set_cursor method as it is used in selection.js
 [1]: https://github.com/EasyScreenCast/EasyScreenCast/blob/e3a359f/display_module.js
 */
 
-
-/* exported DisplayApi */
 'use strict';
 
 /**
  * @type {{_display(): Meta_Display, number_of_displays(): int}}
  */
-var DisplayApi = {
+export const DisplayApi = {
     /**
      * Returns the Wayland display or screen
      *

--- a/extension.js
+++ b/extension.js
@@ -1,26 +1,24 @@
-const GObject = imports.gi.GObject;
-const St = imports.gi.St;
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
+'use strict';
 
-const GLib = imports.gi.GLib;
-const Gio = imports.gi.Gio;
-const Gtk = imports.gi.Gtk;
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import St from 'gi://St';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Meta = ExtensionUtils.getCurrentExtension();
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+
+import * as Selection from './selection.js';
 
 const ButtonName = "ForceQuitButton";
 
-let button;
-
-const Selection = Meta.imports.selection;
-
-
 let ForceQuitButton = GObject.registerClass(
 class ForceQuitButton extends PanelMenu.Button {
-    _init() {
+    _init(extensionPath) {
         super._init(0.0, ButtonName)
+
+        this._extensionPath = extensionPath;
 
         let icon = new St.Icon({
             // icon_name: 'window-close',
@@ -36,21 +34,26 @@ class ForceQuitButton extends PanelMenu.Button {
 
     _getCustIcon(icon_name) {
         let gicon = Gio.icon_new_for_string(
-            Meta.dir.get_child("icons").get_path() + "/" + icon_name + ".svg"
+            `${this._extensionPath}/icons/${icon_name}.svg`
         );
         return gicon;
     }
 });
 
-function enable() {
-    button = new ForceQuitButton();
+export default class ForceQuitExtension extends Extension {
+    enable() {
+        this._button = new ForceQuitButton(this.path);
 
-    // Uncomment following line to get it to the left panel besides AppMenu
-    // Main.panel.addToStatusArea(ButtonName, button, 3, 'left');
-    Main.panel.addToStatusArea(ButtonName, button);
+        // Uncomment following line to get it to the left panel besides AppMenu
+        // Main.panel.addToStatusArea(ButtonName, this._button, 3, 'left');
+        Main.panel.addToStatusArea(ButtonName, this._button);
+    }
+
+    disable() {
+        if (this._button !== null) {
+            this._button.destroy();
+            this._button = null;
+        }
+    }
 }
 
-function disable() {
-    button.destroy();
-    button = null;
-}

--- a/metadata.json
+++ b/metadata.json
@@ -4,11 +4,7 @@
   "name": "Force Quit",
   "gettext-domain": "fq@megh",
   "shell-version": [
-    "40",
-    "41",
-    "42",
-    "43",
-    "44"
+    "45"
   ],
   "url": "https://github.com/meghprkh/force-quit/",
   "uuid": "fq@megh",

--- a/selection.js
+++ b/selection.js
@@ -28,35 +28,25 @@ of classes. Also removed classes SelectionArea, SelectionDesktop & AreaRecording
 [1]: https://github.com/EasyScreenCast/EasyScreenCast/blob/2b26b6d/selection.js
 */
 
-/* exported SelectionWindow */
 'use strict';
 
-const GObject = imports.gi.GObject;
+import GObject from 'gi://GObject';
+import Meta from 'gi://Meta';
+import Clutter from 'gi://Clutter';
+import St from 'gi://St';
+
+import {gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+// Attention: This module is not available as an ECMAScript Module
+// https://gjs-docs.gnome.org/gjs/signals.md
 const Signals = imports.signals;
-const Meta = imports.gi.Meta;
-const Clutter = imports.gi.Clutter;
-const St = imports.gi.St;
-const Layout = imports.ui.layout;
 
-const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as Lib from './convenience.js';
+import * as UtilNotify from './utilnotify.js';
+import {DisplayApi} from './display_module.js';
 
-const Domain = imports.gettext.domain(Me.metadata['gettext-domain']);
-const _ = Domain.gettext;
-
-const Lib = Me.imports.convenience;
-// const Ext = Me.imports.extension;
-const UtilNotify = Me.imports.utilnotify;
-const DisplayApi = Me.imports.display_module.DisplayApi;
-
-const Config = imports.misc.config;
-const shellVersion = Number.parseInt(Config.PACKAGE_VERSION.split('.')[0]);
-
-/**
- * @type {Lang.Class}
- */
 const Capture = GObject.registerClass({
     GTypeName: 'ForceQuit_Capture',
 }, class Capture extends GObject.Object {
@@ -93,20 +83,10 @@ const Capture = GObject.registerClass({
         this._grab = Main.pushModal(this._areaSelection);
 
         if (this._grab) {
-            if (shellVersion >= 42) {
-                this._signalCapturedEvent = this._areaSelection.connect(
-                    'captured-event',
-                    this._onCaptureEvent.bind(this)
-                );
-            } else {
-                this._grab = this._areaSelection;
-                this._signalCapturedEvent = global.stage.connect(
-                    'captured-event',
-                    this._onCaptureEvent.bind(this)
-                );
-            }
-
-
+            this._signalCapturedEvent = this._areaSelection.connect(
+                'captured-event',
+                this._onCaptureEvent.bind(this)
+            );
 
             this._setCaptureCursor();
         } else {
@@ -214,7 +194,7 @@ const Capture = GObject.registerClass({
 
 Signals.addSignalMethods(Capture.prototype);
 
-var SelectionWindow = GObject.registerClass({
+export const SelectionWindow = GObject.registerClass({
     GTypeName: 'ForceQuit_SelectionWindow',
 }, class SelectionWindow extends GObject.Object {
     /**

--- a/utilnotify.js
+++ b/utilnotify.js
@@ -17,26 +17,22 @@ edits, primary deletions. Edits include removal of settings.
 [1]: https://github.com/EasyScreenCast/EasyScreenCast/blob/d94dfdd/utilnotify.js
 */
 
-/* exported NotifyManager */
 'use strict';
 
-const GObject = imports.gi.GObject;
-const Main = imports.ui.main;
-// https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js
-const MessageTray = imports.ui.messageTray;
-const Clutter = imports.gi.Clutter;
-const St = imports.gi.St;
+import GObject from 'gi://GObject';
+import Clutter from 'gi://Clutter';
+import St from 'gi://St';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Lib = Me.imports.convenience;
-// const Settings = Me.imports.settings;
-// const Ext = Me.imports.extension;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+// https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js
+import * as MessageTray from 'resource:///org/gnome/shell/ui/messageTray.js';
+
+import * as Lib from './convenience.js';
 
 /**
  * @type {NotifyManager}
  */
-var NotifyManager = GObject.registerClass({
+export const NotifyManager = GObject.registerClass({
     GTypeName: 'ForceQuit_NotifyManager',
 }, class NotifyManager extends GObject.Object {
     /**
@@ -56,8 +52,8 @@ var NotifyManager = GObject.registerClass({
      */
     createNotify(msg, icon, sound) {
         Lib.TalkativeLog(`-°-create notify :${msg}`);
-        var source = new MessageTray.SystemNotificationSource();
-        var notify = new MessageTray.Notification(source, msg, null, {
+        let source = new MessageTray.SystemNotificationSource();
+        let notify = new MessageTray.Notification(source, msg, null, {
             gicon: icon,
         });
 
@@ -102,9 +98,9 @@ var NotifyManager = GObject.registerClass({
     createAlert(msg) {
         Lib.TalkativeLog(`-°-show alert tweener : ${msg}`);
         if (true) { // can be changed to a setting in future versions
-            var monitor = Main.layoutManager.focusMonitor;
+            let monitor = Main.layoutManager.focusMonitor;
 
-            var text = new St.Label({
+            let text = new St.Label({
                 style_class: 'alert-msg',
                 text: msg,
             });


### PR DESCRIPTION
Since ESM files contain import and export keywords, extension modules won't be compatible with older GNOME Shell versions. The old shell versions must be removed and only use 45 in shell-version in metadata.json!

[Port Extensions to GNOME Shell 45](https://gjs.guide/extensions/upgrading/gnome-shell-45.html#shell-version)